### PR TITLE
create room when no query param present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+# Local Netlify folder
+.netlify

--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 # Local Netlify folder
-.netlify
+.netlify/
+

--- a/README.md
+++ b/README.md
@@ -17,13 +17,21 @@ This is a companion repo to our [chrome extension demo](https://github.com/daily
 
 ## How the demo works
 
+### Frontend
+
 The frontend part of this demo renders our prebuilt UI in a fullscreen iframe and looks for two query parameters: 
 - `room` - the url of the call 
 - `screenshare` - whether to automatically start a screenshare 
 
 This means if you visit `https://your-netlify-site.netlify.app/?room=https://mydomain.daily.co/roomname&screenshare=true` it will join a meeting at the room url specified and prompt you to start a screenshare. 
 
-It also contains a serverless function that is meant to be deployed to Netlify that will create rooms for you. This allows the chrome extension to create a unique room whenever you click "Create and launch call". 
+If no `room` parameter is present it will create a new one and update the url so you can share it. 
+
+### Backend
+
+By default, this demo uses [Netlify Redirects](https://docs.netlify.com/routing/redirects/rewrites-proxies/#proxy-to-another-service) to proxy the [Daily REST API](https://docs.daily.co/reference#rooms). You can see how this works in `netlify.toml`. 
+
+If you require more control over the API requests, there is also a sample serverless function that can be deployed to Netlify that will create rooms for you. You can use this instead of the proxy. Just uncomment the `functions` line in `netlify.toml`. 
 
 ## Contributing and feedback
 
@@ -31,4 +39,4 @@ Let us know how experimenting with this demo goes! Feel free to reach out to us 
 
 ## What's next
 
-Try customizing the landing page you see after leaving a meeting, or add support for other query parameters! 
+Try customizing the landing page you see after leaving a meeting, or add support for other query parameters or additional endpoints! 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ By default, this demo uses [Netlify Redirects](https://docs.netlify.com/routing/
 
 If you require more control over the API requests, there is also a sample serverless function that can be deployed to Netlify that will create rooms for you. You can use this instead of the proxy. Just uncomment the `functions` line in `netlify.toml`. 
 
+## Local dev
+
+Install Netlify CLI globally:
+
+`npm i -g netlify-cli`
+
+Run dev server:
+
+`netlify dev`
+
+> If you need the API proxy locally then add your API key to `netlify.toml`, **but make sure you remove it before you commit any changes**.
+
 ## Contributing and feedback
 
 Let us know how experimenting with this demo goes! Feel free to reach out to us any time at `help@daily.co`.

--- a/functions/rooms.js
+++ b/functions/rooms.js
@@ -19,7 +19,7 @@ const router = express.Router();
 
 router.use(compression());
 
-const routerBasePath = process.env.NODE_ENV === 'dev' ? `/rooms` : `/.netlify/functions/rooms`;
+const routerBasePath =  `/.netlify/functions/rooms`;
 
 console.log(routerBasePath)
 
@@ -66,7 +66,7 @@ const apiHelper = async (method, endpoint, body = {}) => {
 app.use(routerBasePath, router);
 
 // Apply express middlewares
-router.use(cors());
+// router.use(cors());
 router.use(bodyParser.json());
 
 module.exports.handler = serverless(app);

--- a/functions/rooms.js
+++ b/functions/rooms.js
@@ -1,7 +1,3 @@
-// server.js
-// where your node app starts
-// we've started you off with Express (https://expressjs.com/) and axios (https://github.com/axios/axios)
-// but feel free to use whatever libraries or frameworks you'd like through `package.json`.
 const express = require("express");
 const axios = require("axios");
 const cors = require("cors");
@@ -66,7 +62,7 @@ const apiHelper = async (method, endpoint, body = {}) => {
 app.use(routerBasePath, router);
 
 // Apply express middlewares
-// router.use(cors());
+router.use(cors());
 router.use(bodyParser.json());
 
 module.exports.handler = serverless(app);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function showEvent(e) {
   console.log('video call event -->', e);
 }
 
-function createRoom() {
+async function createRoom() {
   const newRoomEndpoint = `${window.location.origin}/.netlify/functions/rooms`;
 
   try {
@@ -23,7 +23,7 @@ async function run() {
   // in the following format: 
   // https://some-netlify-url.com/?room=https://mysubdomain.daily.co/roomname&screenshare=true
   const params = new URLSearchParams(window.location.search);
-  const room = params.get("room") || createRoom();
+  const room = params.get("room") || await createRoom();
   const shareScreenOnJoin = params.get("screenshare");
 
   // Create the DailyIframe, passing styling properties to make it fullscreen

--- a/index.js
+++ b/index.js
@@ -4,12 +4,26 @@ function showEvent(e) {
   console.log('video call event -->', e);
 }
 
+function createRoom() {
+  const newRoomEndpoint = `${window.location.origin}/.netlify/functions/rooms`;
+
+  try {
+    let response = await fetch(newRoomEndpoint, {
+      method: 'POST'
+    }),
+      room = await response.json();
+    return room.url;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
 async function run() {
   // we're assuming an incoming url from the chrome extension
   // in the following format: 
   // https://some-netlify-url.com/?room=https://mysubdomain.daily.co/roomname&screenshare=true
   const params = new URLSearchParams(window.location.search);
-  const room = params.get("room") || 'INSERT_FALLBACK_ROOM_URL';
+  const room = params.get("room") || createRoom();
   const shareScreenOnJoin = params.get("screenshare");
 
   // Create the DailyIframe, passing styling properties to make it fullscreen

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ function showEvent(e) {
 }
 
 async function createRoom() {
-  const newRoomEndpoint = `${window.location.origin}/.netlify/functions/rooms`;
+  
+  const newRoomEndpoint = `${window.location.origin}/api/rooms`;
 
   try {
     let response = await fetch(newRoomEndpoint, {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ function showEvent(e) {
 
 async function createRoom() {
   
+  // This endpoint is using the proxy as outlined in netlify.toml
+  // If you prefer to use the Netlify function then update the path below accordingly
   const newRoomEndpoint = `${window.location.origin}/api/rooms`;
 
   try {
@@ -41,6 +43,11 @@ async function run() {
 
   function doAfterJoin(e){ 
     showEvent(e);
+
+    //update query param so url is shareable
+    const url = new URL(window.location);
+    url.searchParams.set('room', room);
+    window.history.pushState({}, '', url);
 
     if (shareScreenOnJoin) {
       callFrame.startScreenShare();

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  functions = "functions"
+  # functions = "functions/"
+  command = "sed -i s/DAILY_API_KEY_PLACEHOLDER/${DAILY_API_KEY}/g netlify.toml"
 
 [template.environment]
   DAILY_API_KEY = "Replace with API key"
@@ -9,3 +10,10 @@
   for = "/*"
     [headers.values]
     Access-Control-Allow-Origin = "*"
+
+[[redirects]]
+  from = "/api/rooms"
+  to = "https://api.daily.co/v1/rooms"
+  status = 200
+  force = true
+  headers = {Authorization = "Bearer DAILY_API_KEY_PLACEHOLDER"}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,17 +1,18 @@
 [build]
+  # If you prefer to use a Netlify function to make the API calls
+  # uncomment the line below, and change the endpoint in index.js
   # functions = "functions/"
   command = "sed -i s/DAILY_API_KEY_PLACEHOLDER/${DAILY_API_KEY}/g netlify.toml"
 
 [template.environment]
   DAILY_API_KEY = "Replace with API key"
 
-[[headers]]
-  # Define which paths this specific [[headers]] block will cover.
-  for = "/*"
-    [headers.values]
-    Access-Control-Allow-Origin = "*"
-
 [[redirects]]
+  # Proxies the Daily /rooms endpoint, POST will create a room and a GET will return a list 
+  # The placeholder below gets replaced when the build command above runs
+  # as suggested here: https://docs.netlify.com/configure-builds/file-based-configuration/#inject-environment-variable-values
+  # IF YOU RUN THIS COMMAND LOCALLY DO NOT COMMIT THIS FILE WITH THE API KEY IN IT
+  # MAKE SURE THE PLACEHOLDER TEXT IS THERE WHENEVER YOU ARE DONE TESTING LOCALLY
   from = "/api/rooms"
   to = "https://api.daily.co/v1/rooms"
   status = 200


### PR DESCRIPTION
This creates a room via the local endpoint when no query parameter is present. This makes this demo more standalone. 

Companion PR: https://github.com/daily-demos/screenshare-chrome-ext/pull/2